### PR TITLE
fix: await i2cWrite promise

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ export const integerToUint16 = (value: number): Buffer => {
 export const booleanToUint16 = (value: boolean): Buffer => integerToUint16(value ? 1 : 0);
 
 export const write = async (bus: PromisifiedBus, buf: Buffer): Promise<void> => {
-  bus.i2cWrite(SCD30_ADDRESS, buf.length, buf);
+  await bus.i2cWrite(SCD30_ADDRESS, buf.length, buf);
 };
 
 export const read = async (bus: PromisifiedBus, length: number): Promise<Buffer> => {


### PR DESCRIPTION
When performing a command right before disconnecting from the bus, the command may actually fail:

```
[Error: EBADF: bad file descriptor, write] {
  errno: -9,
  code: 'EBADF',
  syscall: 'write'
}
```

This happens because the `write()` operation in [utils.ts](https://github.com/rsmeral/scd30-node/blob/master/src/util.ts#L17-L19) does not await or return the Promise returned from the i2c-bus operation.